### PR TITLE
Add variables into the parser.

### DIFF
--- a/core/src/main/java/org/nwapw/abacus/Abacus.java
+++ b/core/src/main/java/org/nwapw/abacus/Abacus.java
@@ -53,7 +53,7 @@ public class Abacus {
         numberReducer = new NumberReducer(this);
         this.configuration = new Configuration(configuration);
         LexerTokenizer lexerTokenizer = new LexerTokenizer();
-        ShuntingYardParser shuntingYardParser = new ShuntingYardParser(this);
+        ShuntingYardParser shuntingYardParser = new ShuntingYardParser();
         treeBuilder = new TreeBuilder<>(lexerTokenizer, shuntingYardParser);
 
         pluginManager.addListener(shuntingYardParser);

--- a/core/src/main/java/org/nwapw/abacus/parsing/LexerTokenizer.java
+++ b/core/src/main/java/org/nwapw/abacus/parsing/LexerTokenizer.java
@@ -34,6 +34,7 @@ public class LexerTokenizer implements Tokenizer<Match<TokenType>>, PluginListen
             register(" ", TokenType.WHITESPACE);
             register(",", TokenType.COMMA);
             register("[0-9]*(\\.[0-9]+)?", TokenType.NUM);
+            register("[a-zA-Z]+", TokenType.VARIABLE);
             register("\\(", TokenType.OPEN_PARENTH);
             register("\\)", TokenType.CLOSE_PARENTH);
         }};

--- a/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
+++ b/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
@@ -61,7 +61,7 @@ public class ShuntingYardParser implements Parser<Match<TokenType>>, PluginListe
             Match<TokenType> match = from.remove(0);
             previousType = matchType;
             matchType = match.getType();
-            if (matchType == TokenType.NUM) {
+            if (matchType == TokenType.NUM || matchType == TokenType.VARIABLE) {
                 output.add(match);
             } else if (matchType == TokenType.FUNCTION) {
                 output.add(new Match<>("", TokenType.INTERNAL_FUNCTION_END));
@@ -144,6 +144,8 @@ public class ShuntingYardParser implements Parser<Match<TokenType>>, PluginListe
             }
         } else if (matchType == TokenType.NUM) {
             return new NumberNode(abacus.numberFromString(match.getContent()));
+        } else if (matchType == TokenType.VARIABLE) {
+            return new VariableNode(match.getContent());
         } else if (matchType == TokenType.FUNCTION) {
             String functionName = match.getContent();
             FunctionNode node = new FunctionNode(functionName);

--- a/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
+++ b/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
@@ -143,7 +143,7 @@ public class ShuntingYardParser implements Parser<Match<TokenType>>, PluginListe
                 else return new UnaryNode(operator, applyTo);
             }
         } else if (matchType == TokenType.NUM) {
-            return new NumberNode(abacus.numberFromString(match.getContent()));
+            return new NumberNode(match.getContent());
         } else if (matchType == TokenType.VARIABLE) {
             return new VariableNode(match.getContent());
         } else if (matchType == TokenType.FUNCTION) {

--- a/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
+++ b/core/src/main/java/org/nwapw/abacus/parsing/ShuntingYardParser.java
@@ -1,6 +1,5 @@
 package org.nwapw.abacus.parsing;
 
-import org.nwapw.abacus.Abacus;
 import org.nwapw.abacus.function.Operator;
 import org.nwapw.abacus.function.OperatorAssociativity;
 import org.nwapw.abacus.function.OperatorType;
@@ -18,10 +17,6 @@ import java.util.*;
 public class ShuntingYardParser implements Parser<Match<TokenType>>, PluginListener {
 
     /**
-     * The Abacus instance used to create number instances.
-     */
-    private Abacus abacus;
-    /**
      * Map of operator precedences, loaded from the plugin operators.
      */
     private Map<String, Integer> precedenceMap;
@@ -35,12 +30,9 @@ public class ShuntingYardParser implements Parser<Match<TokenType>>, PluginListe
     private Map<String, OperatorType> typeMap;
 
     /**
-     * Creates a new Shunting Yard parser with the given Abacus instance.
-     *
-     * @param abacus the abacus instance.
+     * Creates a new Shunting Yard parser.
      */
-    public ShuntingYardParser(Abacus abacus) {
-        this.abacus = abacus;
+    public ShuntingYardParser() {
         precedenceMap = new HashMap<>();
         associativityMap = new HashMap<>();
         typeMap = new HashMap<>();

--- a/core/src/main/java/org/nwapw/abacus/tree/NumberReducer.java
+++ b/core/src/main/java/org/nwapw/abacus/tree/NumberReducer.java
@@ -28,6 +28,8 @@ public class NumberReducer implements Reducer<NumberInterface> {
     public NumberInterface reduceNode(TreeNode node, Object... children) {
         if (node instanceof NumberNode) {
             return ((NumberNode) node).getNumber();
+        } else if(node instanceof VariableNode) {
+            return abacus.numberFromString("0");
         } else if (node instanceof BinaryNode) {
             NumberInterface left = (NumberInterface) children[0];
             NumberInterface right = (NumberInterface) children[1];

--- a/core/src/main/java/org/nwapw/abacus/tree/NumberReducer.java
+++ b/core/src/main/java/org/nwapw/abacus/tree/NumberReducer.java
@@ -27,7 +27,7 @@ public class NumberReducer implements Reducer<NumberInterface> {
     @Override
     public NumberInterface reduceNode(TreeNode node, Object... children) {
         if (node instanceof NumberNode) {
-            return ((NumberNode) node).getNumber();
+            return abacus.numberFromString(((NumberNode) node).getNumber());
         } else if(node instanceof VariableNode) {
             return abacus.numberFromString("0");
         } else if (node instanceof BinaryNode) {

--- a/core/src/main/java/org/nwapw/abacus/tree/TokenType.java
+++ b/core/src/main/java/org/nwapw/abacus/tree/TokenType.java
@@ -7,7 +7,7 @@ package org.nwapw.abacus.tree;
 public enum TokenType {
 
     INTERNAL_FUNCTION_END(-1),
-    ANY(0), WHITESPACE(1), COMMA(2), OP(3), NUM(4), FUNCTION(5), OPEN_PARENTH(6), CLOSE_PARENTH(7);
+    ANY(0), WHITESPACE(1), COMMA(2), OP(3), NUM(4), VARIABLE(5), FUNCTION(6), OPEN_PARENTH(7), CLOSE_PARENTH(8);
 
     /**
      * The priority by which this token gets sorted.

--- a/core/src/main/kotlin/org/nwapw/abacus/tree/NumberNode.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/tree/NumberNode.kt
@@ -10,14 +10,14 @@ import org.nwapw.abacus.number.NumberInterface
  *
  * @number the number value of this node.
  */
-data class NumberNode(val number: NumberInterface) : TreeNode() {
+data class NumberNode(val number: String) : TreeNode() {
 
     override fun <T : Any> reduce(reducer: Reducer<T>): T? {
         return reducer.reduceNode(this)
     }
 
     override fun toString(): String {
-        return number.toString()
+        return number
     }
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/tree/VariableNode.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/tree/VariableNode.kt
@@ -1,0 +1,21 @@
+package org.nwapw.abacus.tree
+
+/**
+ * A tree node that holds a placeholder variable.
+ *
+ * This node holds a variable string, and acts similarly to a number,
+ * with the key difference of not actually holding a value at runtime.
+ *
+ * @param variable the actual variable name that this node represents.
+ */
+data class VariableNode(val variable: String) : TreeNode() {
+
+    override fun <T : Any> reduce(reducer: Reducer<T>): T? {
+        return reducer.reduceNode(this)
+    }
+
+    override fun toString(): String {
+        return variable
+    }
+
+}

--- a/core/src/test/java/org/nwapw/abacus/tests/CalculationTests.java
+++ b/core/src/test/java/org/nwapw/abacus/tests/CalculationTests.java
@@ -101,7 +101,7 @@ public class CalculationTests {
         testOutput("2^50", "(2^50)", "112589990684262");
         testOutput("7^(-sqrt2*17)", "(7^((sqrt(2)*17))`)", "4.81354609155297814551845300063563");
         testEvalError("0^0", "(0^0)");
-        testEvalError("(-13)^.9999", "((13)`^0.9999)");
+        testEvalError("(-13)^.9999", "((13)`^.9999)");
     }
 
 }


### PR DESCRIPTION
This PR does not add implicit multiplication, nor does it add the substitution of variables for something else. Rather, it allows the parser to recognize variables as they are passed to it, without confusing them for function names. Currently, these variables are simply substituted with 0. 