### PR TITLE
Add dokka plugin to generate documentation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,22 @@
+buildscript {
+    ext.kotlin_version = '1.1.3'
+    ext.dokka_version = '0.9.15'
+
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
+    }
+}
+
 subprojects {
 
     apply plugin: 'java'
+    apply plugin: 'kotlin'
+    apply plugin: 'org.jetbrains.dokka'
 
     repositories {
         mavenCentral()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.1.3'
-}
-
 dependencies {
     compile 'com.moandjiezana.toml:toml4j:0.7.1'
     testCompile 'junit:junit:4.12'

--- a/fx/build.gradle
+++ b/fx/build.gradle
@@ -1,6 +1,3 @@
-plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.1.3'
-}
 apply plugin: 'application'
 
 dependencies {


### PR DESCRIPTION
Dokka is a Kotlin documentation tool. This PR adds the plugin to Gradle, which adds the `dokka` task. This task can be used to generate documentation from the JavaDoc and KDoc comments that are found throughout the source code.