### PR TITLE
Make some parts of the code more thread safe.

### DIFF
--- a/core/src/main/java/org/nwapw/abacus/plugin/PluginManager.java
+++ b/core/src/main/java/org/nwapw/abacus/plugin/PluginManager.java
@@ -141,6 +141,7 @@ public class PluginManager {
         registeredNumberImplementations.put(name, implementation);
         interfaceImplementationNames.put(implementation.getImplementation(), name);
         interfaceImplementations.put(implementation.getImplementation(), implementation);
+        cachedPi.put(implementation.getImplementation(), implementation.instanceForPi());
     }
 
     /**
@@ -218,10 +219,6 @@ public class PluginManager {
                 break;
             }
         }
-        if (toReturn == null) {
-            toReturn = new Documentation(name, "", "", "", type);
-            registerDocumentation(toReturn);
-        }
         return toReturn;
     }
 
@@ -252,14 +249,7 @@ public class PluginManager {
      * @return pi
      */
     public NumberInterface piFor(Class<? extends NumberInterface> forClass) {
-        if (cachedPi.containsKey(forClass)) return cachedPi.get(forClass);
-        NumberImplementation implementation = interfaceImplementationFor(forClass);
-        NumberInterface generatedPi = null;
-        if (implementation != null) {
-            generatedPi = implementation.instanceForPi();
-        }
-        cachedPi.put(forClass, generatedPi);
-        return generatedPi;
+        return cachedPi.get(forClass);
     }
 
     /**

--- a/core/src/main/java/org/nwapw/abacus/plugin/StandardPlugin.java
+++ b/core/src/main/java/org/nwapw/abacus/plugin/StandardPlugin.java
@@ -696,8 +696,7 @@ public class StandardPlugin extends Plugin {
      * @param n              non-negative integer.
      * @return a number of numClass with value n factorial.
      */
-    public static NumberInterface factorial(NumberImplementation implementation, int n) {
-
+    synchronized public static NumberInterface factorial(NumberImplementation implementation, int n) {
         if (!FACTORIAL_LISTS.containsKey(implementation)) {
             FACTORIAL_LISTS.put(implementation, new ArrayList<>());
             FACTORIAL_LISTS.get(implementation).add(implementation.instanceForString("1"));

--- a/core/src/main/kotlin/org/nwapw/abacus/number/PromotionManager.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/number/PromotionManager.kt
@@ -38,21 +38,6 @@ class PromotionManager(val abacus: Abacus) : PluginListener {
     }
 
     /**
-     * If a path between the given implementations has already been computed, uses
-     * the already calculated path. Otherwise, calls [computePathBetween] to compute a new
-     * path.
-     *
-     * @param from the implementation to start from.
-     * @param to the implementation to get to.
-     * @return the resulting promotion path, or null if it is not found
-     */
-    fun getPathBetween(from: NumberImplementation, to: NumberImplementation): PromotionPath? {
-        return computePaths.computeIfAbsent(from to to, {
-             computePathBetween(it.first, it.second)
-        })
-    }
-
-    /**
      * Promote all the numbers in the list to the same number implementation, to ensure
      * they can be used with each other. Finds the highest priority implementation
      * in the list, and promotes all other numbers to it.
@@ -66,16 +51,26 @@ class PromotionManager(val abacus: Abacus) : PluginListener {
         val highestPriority = implementations.sortedBy { it.priority }.last()
         return PromotionResult(items = numbers.map {
             if(it.javaClass == highestPriority.implementation) it
-            else getPathBetween(pluginManager.interfaceImplementationFor(it.javaClass), highestPriority)
+            else computePaths[pluginManager.interfaceImplementationFor(it.javaClass) to highestPriority]
                     ?.promote(it) ?: return null
         }.toTypedArray(), promotedTo = highestPriority)
     }
 
-    override fun onLoad(manager: PluginManager?) {
+    override fun onLoad(manager: PluginManager) {
+        val implementations = manager.allNumberImplementations.map { manager.numberImplementationFor(it) }
+        for((index, value) in implementations.withIndex()){
+            for(i in index until implementations.size){
+                val other = implementations[i]
 
+                val promoteFrom = if(other.priority > value.priority) value else other
+                val promoteTo = if(other.priority > value.priority) other else value
+                val path = computePathBetween(promoteFrom, promoteTo)
+                computePaths.put(promoteFrom to promoteTo, path)
+            }
+        }
     }
 
-    override fun onUnload(manager: PluginManager?) {
+    override fun onUnload(manager: PluginManager) {
         computePaths.clear()
     }
 

--- a/fx/src/main/java/org/nwapw/abacus/fx/AbacusController.java
+++ b/fx/src/main/java/org/nwapw/abacus/fx/AbacusController.java
@@ -363,7 +363,12 @@ public class AbacusController implements PluginListener {
             enabledPlugins.add(plugin);
         }
         PluginManager pluginManager = abacus.getPluginManager();
-        functionList.addAll(manager.getAllFunctions().stream().map(name -> pluginManager.documentationFor(name, DocumentationType.FUNCTION))
+        functionList.addAll(manager.getAllFunctions().stream().map(name -> {
+            Documentation documentationInstance = pluginManager.documentationFor(name, DocumentationType.FUNCTION);
+            if(documentationInstance == null)
+                documentationInstance = new Documentation(name, "", "", "", DocumentationType.FUNCTION);
+            return documentationInstance;
+        })
                 .collect(Collectors.toCollection(ArrayList::new)));
         functionList.addAll(manager.getAllTreeValueFunctions().stream().map(name -> pluginManager.documentationFor(name, DocumentationType.TREE_VALUE_FUNCTION))
                 .collect(Collectors.toCollection(ArrayList::new)));


### PR DESCRIPTION
This PR has Abacus avoid as much as possible storing things into maps during computations. This way, the things in maps can be precomputed, and the maps can't get modified by concurrently running computations.