### PR TITLE
Revert "Remove unnecessary nullability from parseString."

### DIFF
--- a/core/src/main/kotlin/org/nwapw/abacus/Abacus.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/Abacus.kt
@@ -88,7 +88,7 @@ class Abacus(val configuration: Configuration) {
      * @param input the input string to parse
      * @return the resulting tree, null if the tree builder or the produced tree are null.
      */
-    fun parseString(input: String): TreeNode = treeBuilder.fromString(input)
+    fun parseString(input: String): TreeNode? = treeBuilder.fromString(input)
     /**
      * Evaluates the given tree.
      *


### PR DESCRIPTION
This was an incorrect commit, as is evident by the exceptions it throws.