### PR TITLE
Fix a bug that made some same-priority implementations not convert.

### DIFF
--- a/core/src/main/java/org/nwapw/abacus/exception/PromotionException.java
+++ b/core/src/main/java/org/nwapw/abacus/exception/PromotionException.java
@@ -18,7 +18,7 @@ public class PromotionException extends AbacusException {
      * @param message the additional message to include with the error.
      */
     public PromotionException(String message) {
-        super("Failed to promote number instances.", message);
+        super("Failed to promote number instances", message);
     }
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/number/PromotionManager.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/number/PromotionManager.kt
@@ -59,14 +59,12 @@ class PromotionManager(val abacus: Abacus) : PluginListener {
 
     override fun onLoad(manager: PluginManager) {
         val implementations = manager.allNumberImplementations.map { manager.numberImplementationFor(it) }
-        for((index, value) in implementations.withIndex()){
-            for(i in index until implementations.size){
-                val other = implementations[i]
-
-                val promoteFrom = if(other.priority > value.priority) value else other
-                val promoteTo = if(other.priority > value.priority) other else value
+        for(first in implementations) {
+            for(second in implementations) {
+                val promoteFrom = if(second.priority > first.priority) first else second
+                val promoteTo = if(second.priority > first.priority) second else first
                 val path = computePathBetween(promoteFrom, promoteTo)
-                computePaths.put(promoteFrom to promoteTo, path)
+                computePaths[promoteFrom to promoteTo] = path
             }
         }
     }


### PR DESCRIPTION
In cases with same-priority implementations in promotion path computation, the manager would ignore a pair if it previously encountered it in the opposite order. However, since they are of equivalent priority, there's no reason not to allow a bidirectional conversion.