### PR TITLE
Add a NumberRange utility.

### DIFF
--- a/core/src/main/java/org/nwapw/abacus/number/NumberInterface.java
+++ b/core/src/main/java/org/nwapw/abacus/number/NumberInterface.java
@@ -238,4 +238,16 @@ public abstract class NumberInterface implements Comparable<NumberInterface> {
      */
     public abstract NumberInterface getMaxError();
 
+    /**
+     * Returns a NumberRangeBuilder object, which is used to create a range.
+     * The reason that this returns a builder and not an actual range is that
+     * the NumberRange needs to promote values passed to it, which
+     * requires an abacus instance.
+     * @param other the value at the bottom of the range.
+     * @return the resulting range builder.
+     */
+    public NumberRangeBuilder rangeTo(NumberInterface other){
+        return new NumberRangeBuilder(this, other);
+    }
+
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/number/NumberRange.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/number/NumberRange.kt
@@ -1,0 +1,28 @@
+package org.nwapw.abacus.number
+
+import org.nwapw.abacus.Abacus
+
+/**
+ * A closed range designed specifically for [NumberInterface]
+ *
+ * Besides providing the usual functionality of a [ClosedRange], this range
+ * also handles promotion - that is, it's safe to use it with numbers of different
+ * implementations, even as starting and ending points.
+ *
+ * @property abacus the abacus instance used for promotion.
+ * @property start the starting point of the range.
+ * @property endInclusive the ending point of the range.
+ */
+class NumberRange(val abacus: Abacus,
+                  override val start: NumberInterface,
+                  override val endInclusive: NumberInterface): ClosedRange<NumberInterface> {
+
+    override operator fun contains(value: NumberInterface): Boolean {
+        val promotionResult = abacus.promotionManager.promote(start, endInclusive, value)
+        val newStart = promotionResult.items[0]
+        val newEnd = promotionResult.items[1]
+        val newValue = promotionResult.items[2]
+        return newValue >= newStart && newValue <= newEnd
+    }
+
+}

--- a/core/src/main/kotlin/org/nwapw/abacus/number/NumberRangeBuilder.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/number/NumberRangeBuilder.kt
@@ -1,0 +1,24 @@
+package org.nwapw.abacus.number
+
+import org.nwapw.abacus.Abacus
+
+/**
+ * A utility class for creating [NumberRange] instances.
+ *
+ * Unlike a regular [ClosedRange], a NumberRange must have a third parameter,
+ * which is the [Abacus] instance that is used for promotion. However, the ".." operator
+ * is infix, and can only take two parameters. The solution is, instead of returning instances
+ * of NumberRange directly, to return a builder, which then provides a [with] infix function
+ * to attach it to an instance of Abacus.
+ * @property start the beginning of the range.
+ * @property endInclusive the end of the range.
+ */
+class NumberRangeBuilder(private val start: NumberInterface, private val endInclusive: NumberInterface) {
+
+    /**
+     * Generate a [NumberRange] with the given instance of [abacus].
+     * @return a new range with the given instance of Abacus.
+     */
+    infix fun with(abacus: Abacus) = NumberRange(abacus, start, endInclusive)
+
+}

--- a/core/src/test/java/org/nwapw/abacus/tests/RangeTests.java
+++ b/core/src/test/java/org/nwapw/abacus/tests/RangeTests.java
@@ -1,0 +1,97 @@
+package org.nwapw.abacus.tests;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.nwapw.abacus.Abacus;
+import org.nwapw.abacus.config.Configuration;
+import org.nwapw.abacus.number.NaiveNumber;
+import org.nwapw.abacus.number.NumberInterface;
+import org.nwapw.abacus.number.NumberRange;
+import org.nwapw.abacus.number.PreciseNumber;
+import org.nwapw.abacus.plugin.StandardPlugin;
+
+import java.util.function.Function;
+
+public class RangeTests {
+
+    private static Abacus abacus = new Abacus(new Configuration( "precise", new String[]{}));
+    private static Function<NumberInterface, NumberInterface> naivePromotion = i -> new NaiveNumber((i.toString()));
+    private static Function<NumberInterface, NumberInterface> precisePromotion = i -> new PreciseNumber((i.toString()));
+
+    @BeforeClass
+    public static void prepareTests() {
+        abacus.getPluginManager().addInstantiated(new StandardPlugin(abacus.getPluginManager()));
+        abacus.reload();
+    }
+
+    public static NumberRange naiveRange(String bottom, String top) {
+        return new NaiveNumber(bottom).rangeTo(new NaiveNumber(top)).with(abacus);
+    }
+
+    @Test
+    public void testNaiveRange(){
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertTrue(range.getStart().toString().startsWith("0"));
+        Assert.assertTrue(range.getEndInclusive().toString().startsWith("10"));
+    }
+
+    @Test
+    public void testNaiveRangeBelow() {
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertFalse(range.contains(new NaiveNumber("-10")));
+    }
+
+    @Test
+    public void testNaiveRangeAbove() {
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertFalse(range.contains(new NaiveNumber("20")));
+    }
+
+    @Test
+    public void testNaiveRangeJustWithinBottom() {
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertTrue(range.contains(new NaiveNumber("0")));
+    }
+
+    @Test
+    public void testNaiveRangeJustWithinTop() {
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertTrue(range.contains(new NaiveNumber("10")));
+    }
+
+    @Test
+    public void testNaiveRangeWithin() {
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertTrue(range.contains(new NaiveNumber("5")));
+    }
+
+    public static void addTestPromotionPaths() {
+        StandardPlugin.IMPLEMENTATION_NAIVE.getPromotionPaths().put("precise", precisePromotion);
+        StandardPlugin.IMPLEMENTATION_PRECISE.getPromotionPaths().put("naive", naivePromotion);
+        abacus.reload();
+    }
+
+    public static void removeTestPromotionPaths() {
+        StandardPlugin.IMPLEMENTATION_NAIVE.getPromotionPaths().remove("precise");
+        StandardPlugin.IMPLEMENTATION_NAIVE.getPromotionPaths().remove("naive");
+        abacus.reload();
+    }
+
+    @Test
+    public void testPromotionWithin() {
+        addTestPromotionPaths();
+        NumberRange range = naiveRange("0", "10");
+        Assert.assertTrue(range.contains(new PreciseNumber("5")));
+        removeTestPromotionPaths();
+    }
+
+    @Test
+    public void testPromotionOutside(){
+        addTestPromotionPaths();
+        NumberRange range = naiveRange("0","10");
+        Assert.assertFalse(range.contains(new PreciseNumber("20")));
+        removeTestPromotionPaths();
+    }
+
+}


### PR DESCRIPTION
The NumberRange utility class is generated by the use of the `rangeTo` and `with` functions. It provides a consistent way of checking if a `NumberInterface` instance is within a certain range, and handles the promotion from one number type to another.