### PR TITLE
Add an additional, restricted type of context for use only by plugins.

### DIFF
--- a/core/src/main/java/org/nwapw/abacus/plugin/standard/StandardPlugin.java
+++ b/core/src/main/java/org/nwapw/abacus/plugin/standard/StandardPlugin.java
@@ -1,6 +1,8 @@
 package org.nwapw.abacus.plugin.standard;
 
+import org.jetbrains.annotations.NotNull;
 import org.nwapw.abacus.context.MutableEvaluationContext;
+import org.nwapw.abacus.context.PluginEvaluationContext;
 import org.nwapw.abacus.function.Documentation;
 import org.nwapw.abacus.function.DocumentationType;
 import org.nwapw.abacus.function.interfaces.NumberFunction;
@@ -119,12 +121,12 @@ public class StandardPlugin extends Plugin {
      */
     public static final NumberFunction FUNCTION_ABS = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return params[0].multiply(context.getInheritedNumberImplementation().instanceForString(Integer.toString(params[0].signum())));
         }
     };
@@ -133,12 +135,12 @@ public class StandardPlugin extends Plugin {
      */
     public static final NumberFunction FUNCTION_LN = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1 && params[0].compareTo(context.getInheritedNumberImplementation().instanceForString("0")) > 0;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             NumberInterface param = params[0];
             NumberInterface one = implementation.instanceForString("1");
@@ -166,10 +168,12 @@ public class StandardPlugin extends Plugin {
         /**
          * Returns the partial sum of the Taylor series for logx (around x=1).
          * Automatically determines the number of terms needed based on the precision of x.
+         *
+         * @param context
          * @param x value at which the series is evaluated. 0 < x < 2. (x=2 is convergent but impractical.)
          * @return the partial sum.
          */
-        private NumberInterface getLogPartialSum(MutableEvaluationContext context, NumberInterface x) {
+        private NumberInterface getLogPartialSum(PluginEvaluationContext context, NumberInterface x) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             NumberInterface maxError = x.getMaxError();
             x = x.subtract(implementation.instanceForString("1")); //Terms used are for log(x+1).
@@ -214,12 +218,12 @@ public class StandardPlugin extends Plugin {
      */
     public static final NumberFunction FUNCTION_RAND_INT = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return context.getInheritedNumberImplementation().instanceForString(Long.toString(Math.round(Math.random() * params[0].floor().intValue())));
         }
     };
@@ -232,12 +236,12 @@ public class StandardPlugin extends Plugin {
      */
     public static final NumberFunction FUNCTION_SQRT = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return OP_CARET.apply(context, params[0], context.getInheritedNumberImplementation().instanceForString(".5"));
         }
     };
@@ -247,12 +251,12 @@ public class StandardPlugin extends Plugin {
      */
     public static final NumberFunction FUNCTION_EXP = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             NumberInterface maxError = params[0].getMaxError();
             int n = 0;
@@ -285,12 +289,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionSin = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             NumberInterface pi = piFor(params[0].getClass());
             NumberInterface twoPi = pi.multiply(implementation.instanceForString("2"));
@@ -310,12 +314,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionCos = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return functionSin.apply(context, piFor(params[0].getClass()).divide(context.getInheritedNumberImplementation().instanceForString("2"))
                     .subtract(params[0]));
         }
@@ -325,12 +329,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionTan = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return functionSin.apply(context, params[0]).divide(functionCos.apply(context, params[0]));
         }
     };
@@ -339,12 +343,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionSec = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return context.getInheritedNumberImplementation().instanceForString("1").divide(functionCos.apply(context, params[0]));
         }
     };
@@ -353,12 +357,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionCsc = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return context.getInheritedNumberImplementation().instanceForString("1").divide(functionSin.apply(context, params[0]));
         }
     };
@@ -367,12 +371,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionCot = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return functionCos.apply(context, params[0]).divide(functionSin.apply(context, params[0]));
         }
     };
@@ -382,13 +386,13 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArcsin = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1
                     && FUNCTION_ABS.apply(context, params[0]).compareTo(context.getInheritedNumberImplementation().instanceForString("1")) <= 0;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             if (FUNCTION_ABS.apply(context, params[0]).compareTo(implementation.instanceForString(".8")) >= 0) {
                 NumberInterface[] newParams = {FUNCTION_SQRT.apply(context, implementation.instanceForString("1").subtract(params[0].multiply(params[0])))};
@@ -416,12 +420,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArccos = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1 && FUNCTION_ABS.apply(context, params[0]).compareTo(context.getInheritedNumberImplementation().instanceForString("1")) <= 0;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return piFor(params[0].getClass()).divide(context.getInheritedNumberImplementation().instanceForString("2"))
                     .subtract(functionArcsin.apply(context, params));
         }
@@ -432,12 +436,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArccsc = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1 && FUNCTION_ABS.apply(context, params[0]).compareTo(context.getInheritedNumberImplementation().instanceForString("1")) >= 0;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberInterface[] reciprocalParamArr = {context.getInheritedNumberImplementation().instanceForString("1").divide(params[0])};
             return functionArcsin.apply(context, reciprocalParamArr);
         }
@@ -448,12 +452,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArcsec = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1 && FUNCTION_ABS.apply(context, params[0]).compareTo(context.getInheritedNumberImplementation().instanceForString("1")) >= 0;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberInterface[] reciprocalParamArr = {context.getInheritedNumberImplementation().instanceForString("1").divide(params[0])};
             return functionArccos.apply(context, reciprocalParamArr);
         }
@@ -464,12 +468,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArctan = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             NumberImplementation implementation = context.getInheritedNumberImplementation();
             if (params[0].signum() == -1) {
                 NumberInterface[] negatedParams = {params[0].negate()};
@@ -506,12 +510,12 @@ public class StandardPlugin extends Plugin {
      */
     public final NumberFunction functionArccot = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 1;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return piFor(params[0].getClass()).divide(context.getInheritedNumberImplementation().instanceForString("2"))
                     .subtract(functionArctan.apply(context, params));
         }
@@ -550,7 +554,7 @@ public class StandardPlugin extends Plugin {
      * @param x where the series is evaluated.
      * @return the value of the series
      */
-    private static NumberInterface sinTaylor(MutableEvaluationContext context, NumberInterface x) {
+    private static NumberInterface sinTaylor(PluginEvaluationContext context, NumberInterface x) {
         NumberInterface power = x, multiplier = x.multiply(x).negate(), currentTerm, sum = x;
         NumberInterface maxError = x.getMaxError();
         int n = 1;
@@ -569,7 +573,7 @@ public class StandardPlugin extends Plugin {
      * @param phi an angle (in radians).
      * @return theta in [0, 2pi) that differs from phi by a multiple of 2pi.
      */
-    private static NumberInterface getSmallAngle(MutableEvaluationContext context, NumberInterface phi, NumberInterface pi) {
+    private static NumberInterface getSmallAngle(PluginEvaluationContext context, NumberInterface phi, NumberInterface pi) {
         NumberInterface twoPi = pi.multiply(context.getInheritedNumberImplementation().instanceForString("2"));
         NumberInterface theta = FUNCTION_ABS.apply(context, phi).subtract(twoPi
                 .multiply(FUNCTION_ABS.apply(context, phi).divide(twoPi).floor())); //Now theta is in [0, 2pi).

--- a/core/src/main/kotlin/org/nwapw/abacus/context/MutableEvaluationContext.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/context/MutableEvaluationContext.kt
@@ -9,14 +9,15 @@ import org.nwapw.abacus.tree.nodes.*
 
 /**
  * A reduction context that is mutable.
+ *
  * @param parent the parent of this context.
  * @param numberImplementation the number implementation used in this context.
- * @param reducer the reducer used in this context
+ * @param abacus the abacus instance used.
  */
 class MutableEvaluationContext(parent: EvaluationContext? = null,
                                numberImplementation: NumberImplementation? = null,
                                abacus: Abacus? = null) :
-        EvaluationContext(parent, numberImplementation, abacus) {
+        PluginEvaluationContext(parent, numberImplementation, abacus) {
 
     override var numberImplementation: NumberImplementation? = super.numberImplementation
     override var abacus: Abacus? = super.abacus
@@ -35,42 +36,11 @@ class MutableEvaluationContext(parent: EvaluationContext? = null,
         }
     }
 
-    /**
-     * Sets a variable to a certain [value].
-     * @param name the name of the variable.
-     * @param value the value of the variable.
-     */
-    fun setVariable(name: String, value: NumberInterface) {
-        variableMap[name] = value
-    }
-
-    /**
-     * Set a definition to a certain [value].
-     * @param name the name of the definition.
-     * @param value the value of the definition.
-     */
-    fun setDefinition(name: String, value: TreeNode) {
-        definitionMap[name] = value
-    }
-
-    /**
-     * Clears the variables defined in this context.
-     */
-    fun clearVariables(){
-        variableMap.clear()
-    }
-
-    /**
-     * Clears the definitions defined in this context.
-     */
-    fun clearDefinitions(){
-        definitionMap.clear()
-    }
-
     override fun reduceNode(treeNode: TreeNode, vararg children: Any): NumberInterface {
+        val oldNumberImplementation = numberImplementation
         val abacus = inheritedAbacus
         val promotionManager = abacus.promotionManager
-        return when(treeNode){
+        val toReturn = when(treeNode){
             is NumberNode -> {
                 inheritedNumberImplementation.instanceForString(treeNode.number)
             }
@@ -114,6 +84,8 @@ class MutableEvaluationContext(parent: EvaluationContext? = null,
             }
             else -> throw ReductionException("unrecognized tree node.")
         }
+        numberImplementation = oldNumberImplementation
+        return toReturn
     }
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/context/PluginEvaluationContext.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/context/PluginEvaluationContext.kt
@@ -1,0 +1,58 @@
+package org.nwapw.abacus.context
+
+import org.nwapw.abacus.Abacus
+import org.nwapw.abacus.number.NumberInterface
+import org.nwapw.abacus.plugin.NumberImplementation
+import org.nwapw.abacus.tree.nodes.TreeNode
+
+/**
+ * An evaluation context with limited mutability.
+ *
+ * An evaluation context that is mutable but in a limited way, that is, not allowing the modifications
+ * of variables whose changes might cause issues outside of the function. An example of this would be
+ * the modification of the [numberImplementation], which would cause code paths such as the parsing
+ * of NumberNodes to produce a different type of number than if the function did not run, whcih is unacceptable.
+ *
+ * @param parent the parent of this context.
+ * @param numberImplementation the number implementation used in this context.
+ * @param abacus the abacus instance used.
+ */
+abstract class PluginEvaluationContext(parent: EvaluationContext? = null,
+                                       numberImplementation: NumberImplementation? = null,
+                                       abacus: Abacus? = null) :
+        EvaluationContext(parent, numberImplementation, abacus) {
+
+    /**
+     * Sets a variable to a certain [value].
+     * @param name the name of the variable.
+     * @param value the value of the variable.
+     */
+    fun setVariable(name: String, value: NumberInterface) {
+        variableMap[name] = value
+    }
+
+    /**
+     * Set a definition to a certain [value].
+     * @param name the name of the definition.
+     * @param value the value of the definition.
+     */
+    fun setDefinition(name: String, value: TreeNode) {
+        definitionMap[name] = value
+    }
+
+    /**
+     * Clears the variables defined in this context.
+     */
+    fun clearVariables(){
+        variableMap.clear()
+    }
+
+    /**
+     * Clears the definitions defined in this context.
+     */
+    fun clearDefinitions(){
+        definitionMap.clear()
+    }
+
+
+}

--- a/core/src/main/kotlin/org/nwapw/abacus/function/Applicable.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/function/Applicable.kt
@@ -1,6 +1,7 @@
 package org.nwapw.abacus.function
 
 import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.exception.DomainException
 
 /**
@@ -18,7 +19,7 @@ interface Applicable<in T : Any, out O : Any> {
      * @param params the parameter array to verify for compatibility.
      * @return whether the array can be used with applyInternal.
      */
-    fun matchesParams(context: MutableEvaluationContext, params: Array<out T>): Boolean
+    fun matchesParams(context: PluginEvaluationContext, params: Array<out T>): Boolean
 
     /**
      * Applies the applicable object to the given parameters,
@@ -26,7 +27,7 @@ interface Applicable<in T : Any, out O : Any> {
      * @param params the parameters to apply to.
      * @return the result of the application.
      */
-    fun applyInternal(context: MutableEvaluationContext, params: Array<out T>): O
+    fun applyInternal(context: PluginEvaluationContext, params: Array<out T>): O
 
     /**
      * If the parameters can be used with this applicable, returns
@@ -35,7 +36,7 @@ interface Applicable<in T : Any, out O : Any> {
      * @param params the parameters to apply to.
      * @return the result of the operation, or null if parameters do not match.
      */
-    fun apply(context: MutableEvaluationContext, vararg params: T): O {
+    fun apply(context: PluginEvaluationContext, vararg params: T): O {
         if (!matchesParams(context, params))
             throw DomainException("parameters do not match function requirements.")
         return applyInternal(context, params)

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorAdd.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorAdd.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,9 +13,9 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorAdd: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params[0] + params[1]
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorCaret.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorCaret.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -14,12 +14,12 @@ import org.nwapw.abacus.plugin.standard.StandardPlugin.*
  */
 class OperatorCaret: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 2) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2
                     && !(params[0].signum() == 0 && params[1].signum() == 0)
                     && !(params[0].signum() == -1 && !params[1].isInteger())
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
         val implementation = context.inheritedNumberImplementation
         if (params[0].signum() == 0)
             return implementation.instanceForString("0")

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDefine.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDefine.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.TreeValueOperator
@@ -16,10 +16,10 @@ import org.nwapw.abacus.tree.nodes.VariableNode
  */
 class OperatorDefine: TreeValueOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out TreeNode>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out TreeNode>) =
             params.size == 2 && params[0] is VariableNode
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out TreeNode>): NumberInterface {
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out TreeNode>): NumberInterface {
         val assignTo = (params[0] as VariableNode).variable
         context.setDefinition(assignTo, params[1])
         return params[1].reduce(context)

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDivide.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDivide.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,9 +13,9 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorDivide: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params[0] / params[1]
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorFactorial.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorFactorial.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,12 +13,12 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorFactorial: NumberOperator(OperatorAssociativity.LEFT, OperatorType.UNARY_POSTFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
         params.size == 1
                 && params[0].isInteger()
                 && params[0].signum() >= 0
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
         val implementation = context.inheritedNumberImplementation
         val one = implementation.instanceForString("1")
         if (params[0].signum() == 0) {

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorMultiply.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorMultiply.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,9 +13,9 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorMultiply: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params[0] * params[1]
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNcr.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNcr.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -16,11 +16,11 @@ import org.nwapw.abacus.plugin.standard.StandardPlugin.OP_NPR
  */
 class OperatorNcr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2 && params[0].isInteger()
                     && params[1].isInteger()
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             OP_NPR.apply(context, *params) / OP_FACTORIAL.apply(context, params[1])
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNegate.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNegate.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,10 +13,10 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorNegate: NumberOperator(OperatorAssociativity.LEFT, OperatorType.UNARY_PREFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 1
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             -params[0]
 
 }

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNpr.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNpr.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -14,11 +14,11 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorNpr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2 && params[0].isInteger()
                     && params[1].isInteger()
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>): NumberInterface {
         val implementation = context.inheritedNumberImplementation
         if (params[0] < params[1] ||
                 params[0].signum() < 0 ||

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSet.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSet.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.TreeValueOperator
@@ -15,10 +15,10 @@ import org.nwapw.abacus.tree.nodes.VariableNode
  */
 class OperatorSet: TreeValueOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out TreeNode>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out TreeNode>) =
             params.size == 2 && params[0] is VariableNode
 
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out TreeNode>): NumberInterface {
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out TreeNode>): NumberInterface {
         val assignTo = (params[0] as VariableNode).variable
         val value = params[1].reduce(context)
         context.setVariable(assignTo, value)

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSubtract.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSubtract.kt
@@ -1,6 +1,6 @@
 package org.nwapw.abacus.plugin.standard.operator
 
-import org.nwapw.abacus.context.MutableEvaluationContext
+import org.nwapw.abacus.context.PluginEvaluationContext
 import org.nwapw.abacus.function.OperatorAssociativity
 import org.nwapw.abacus.function.OperatorType
 import org.nwapw.abacus.function.interfaces.NumberOperator
@@ -13,9 +13,9 @@ import org.nwapw.abacus.number.NumberInterface
  */
 class OperatorSubtract: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
 
-    override fun matchesParams(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2
-    override fun applyInternal(context: MutableEvaluationContext, params: Array<out NumberInterface>) =
+    override fun applyInternal(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params[0] - params[1]
 
 }

--- a/core/src/test/java/org/nwapw/abacus/tests/TokenizerTests.java
+++ b/core/src/test/java/org/nwapw/abacus/tests/TokenizerTests.java
@@ -1,11 +1,13 @@
 package org.nwapw.abacus.tests;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.nwapw.abacus.Abacus;
 import org.nwapw.abacus.config.Configuration;
 import org.nwapw.abacus.context.MutableEvaluationContext;
+import org.nwapw.abacus.context.PluginEvaluationContext;
 import org.nwapw.abacus.function.OperatorAssociativity;
 import org.nwapw.abacus.function.OperatorType;
 import org.nwapw.abacus.function.interfaces.NumberFunction;
@@ -24,12 +26,12 @@ public class TokenizerTests {
     private static LexerTokenizer lexerTokenizer = new LexerTokenizer();
     private static NumberFunction subtractFunction = new NumberFunction() {
         @Override
-        public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+        public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
             return params.length == 2;
         }
 
         @Override
-        public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+        public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
             return params[0].subtract(params[1]);
         }
     };
@@ -40,12 +42,12 @@ public class TokenizerTests {
                     0) {
 
                 @Override
-                public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+                public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
                     return true;
                 }
 
-                                @Override
-                public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+                @Override
+                public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
                     return subtractFunction.apply(context, params);
                 }
             });
@@ -53,12 +55,12 @@ public class TokenizerTests {
                     0) {
 
                 @Override
-                public boolean matchesParams(MutableEvaluationContext context, NumberInterface[] params) {
+                public boolean matchesParams(PluginEvaluationContext context, NumberInterface[] params) {
                     return true;
                 }
 
-                                @Override
-                public NumberInterface applyInternal(MutableEvaluationContext context, NumberInterface[] params) {
+                @Override
+                public NumberInterface applyInternal(PluginEvaluationContext context, NumberInterface[] params) {
                     return subtractFunction.apply(context, params);
                 }
             });


### PR DESCRIPTION
This prevents plugins from having side effects. This commit also adds a side effect prevention to the full MutableContext, fixing already existing side effects as mentioned in #49.