### PR TITLE
Make sure the set and define operators have the lowest precedence.

### DIFF
--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorAdd.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorAdd.kt
@@ -11,7 +11,7 @@ import org.nwapw.abacus.number.NumberInterface
  *
  * This is a standard operator that simply performs addition.
  */
-class OperatorAdd: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
+class OperatorAdd: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorCaret.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorCaret.kt
@@ -12,7 +12,7 @@ import org.nwapw.abacus.plugin.standard.StandardPlugin.*
  *
  * This is a standard operator that brings one number to the power of the other.
  */
-class OperatorCaret: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 2) {
+class OperatorCaret: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 3) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDivide.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorDivide.kt
@@ -11,7 +11,7 @@ import org.nwapw.abacus.number.NumberInterface
  *
  * This is a standard operator that simply performs division.
  */
-class OperatorDivide: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
+class OperatorDivide: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 2) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorMultiply.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorMultiply.kt
@@ -11,7 +11,7 @@ import org.nwapw.abacus.number.NumberInterface
  *
  * This is a standard operator that simply performs multiplication.
  */
-class OperatorMultiply: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
+class OperatorMultiply: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 2) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNcr.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNcr.kt
@@ -14,7 +14,7 @@ import org.nwapw.abacus.plugin.standard.StandardPlugin.OP_NPR
  * This is a standard operator that returns the number of possible combinations, regardless of order,
  * of a certain size can be taken out of a pool of a bigger size.
  */
-class OperatorNcr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 0) {
+class OperatorNcr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 1) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2 && params[0].isInteger()

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNpr.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorNpr.kt
@@ -12,7 +12,7 @@ import org.nwapw.abacus.number.NumberInterface
  * his is a standard operator that returns the number of possible combinations
  * of a certain size can be taken out of a pool of a bigger size.
  */
-class OperatorNpr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 0) {
+class OperatorNpr: NumberOperator(OperatorAssociativity.RIGHT, OperatorType.BINARY_INFIX, 1) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2 && params[0].isInteger()

--- a/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSubtract.kt
+++ b/core/src/main/kotlin/org/nwapw/abacus/plugin/standard/operator/OperatorSubtract.kt
@@ -11,7 +11,7 @@ import org.nwapw.abacus.number.NumberInterface
  *
  * This is a standard operator that performs subtraction.
  */
-class OperatorSubtract: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 0) {
+class OperatorSubtract: NumberOperator(OperatorAssociativity.LEFT, OperatorType.BINARY_INFIX, 1) {
 
     override fun matchesParams(context: PluginEvaluationContext, params: Array<out NumberInterface>) =
             params.size == 2


### PR DESCRIPTION
This can cause a nasty issue where a user might assign a value, a=10000*10000+5, and the output will be the expected 10000*10000+5, but a will be set to 10000*10000, because both set and add have the same precedence. This fixes that issue.